### PR TITLE
If non-default minOccurs or maxOccurs, specify both

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ The publication of this EBU-TT XML Schema for EBU-TT Metadata is intended to sup
 implementation of the specification in EBU-Tech 3390 version 1.0.
 
 Please note that the EBU-TT XML Schema is a helping document and NOT normative but informative.
+
+## Style guide
+
+Where an element is defined or referenced with either a `minOccurs` or a `maxOccurs`
+that is not the default value (which is 1 for both), _both_ `minOccurs` and `maxOccurs`
+should be explicitly specified.

--- a/ebu-tt-metadata.xsd
+++ b/ebu-tt-metadata.xsd
@@ -700,8 +700,8 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 
 	<xs:complexType name="metadataBase_type">
 		<xs:sequence>
-			<xs:element ref="ttm:title" minOccurs="0"/>
-			<xs:element ref="ttm:desc" minOccurs="0"/>
+			<xs:element ref="ttm:title" minOccurs="0" maxOccurs="1"/>
+			<xs:element ref="ttm:desc" minOccurs="0" maxOccurs="1"/>
 		</xs:sequence>
 	</xs:complexType>
 


### PR DESCRIPTION
Change the two cases where a non-default `minOccurs` is present without a `maxOccurs` also being specified so that both are added, and add this style guidance to the README.

Closes #10 as per the proposed resolution at https://github.com/ebu/ebu-tt-m-xsd/issues/10#issuecomment-502706243.