### PR TITLE
Remove `use="optional"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ The publication of this EBU-TT XML Schema for EBU-TT Metadata is intended to sup
 implementation of the specification in EBU-Tech 3390 version 1.0.
 
 Please note that the EBU-TT XML Schema is a helping document and NOT normative but informative.
+
+## Style Guide
+
+The `use` attribute should only be specified when its value is `required` - in all other
+cases the default `optional` value applies and does not need to be specified.

--- a/ebu-tt-metadata.xsd
+++ b/ebu-tt-metadata.xsd
@@ -543,14 +543,14 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		</xs:sequence>
 		<xs:attribute name="process" type="xs:string" use="required"/>
 		<xs:attribute name="generatedBy" type="xs:anyURI" use="required"/>
-		<xs:attribute name="sourceId" type="xs:anyURI" use="optional"/>
+		<xs:attribute name="sourceId" type="xs:anyURI"/>
 		<xs:attribute name="appliedDateTime" type="xs:dateTime"/>
 	</xs:complexType>
 
 	<xs:complexType name="stlConversionParameter_type">
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
-				<xs:attribute name="key" type="xs:string" use="optional"/>
+				<xs:attribute name="key" type="xs:string"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -565,8 +565,8 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 	<xs:complexType name="facet_type">
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
-				<xs:attribute name="link" type="xs:anyURI" use="optional"/>
-				<xs:attribute name="expresses" use="optional">
+				<xs:attribute name="link" type="xs:anyURI"/>
+				<xs:attribute name="expresses">
 					<xs:simpleType>
 						<xs:restriction base="xs:token">
 							<xs:enumeration value="has"/>
@@ -596,8 +596,8 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
-				<xs:attribute name="link" type="xs:anyURI" use="optional"/>
-				<xs:attribute name="summary" use="optional">
+				<xs:attribute name="link" type="xs:anyURI"/>
+				<xs:attribute name="summary">
 					<xs:simpleType>
 						<xs:restriction base="xs:token">
 							<xs:enumeration value="all_has"/>
@@ -620,12 +620,9 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 				<xs:attribute name="fontFamilyName"
 					type="ebuttdt:fontFamilyType" use="required"/>
 				<xs:attribute name="src" type="xs:anyURI" use="required"/>
-				<xs:attribute name="fontStyle" type="ebuttdt:fontStyleType"
-					use="optional"/>
-				<xs:attribute name="fontWeight" type="ebuttdt:fontWeightType"
-					use="optional"/>
-				<xs:attribute name="fontSize" type="ebuttdt:fontSizeType"
-					use="optional"/>
+				<xs:attribute name="fontStyle" type="ebuttdt:fontStyleType"/>
+				<xs:attribute name="fontWeight" type="ebuttdt:fontWeightType"/>
+				<xs:attribute name="fontSize" type="ebuttdt:fontSizeType"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>


### PR DESCRIPTION
The default value for the `@use` attribute is `optional` so remove specifications that repeat the default. Add this as a style guide instruction in the README.

Closes #11.