### PR TITLE
Remove not directly used datatype definitions

### DIFF
--- a/ebu-tt-datatypes.xsd
+++ b/ebu-tt-datatypes.xsd
@@ -9,43 +9,9 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ebuttdt="urn:ebu:tt:datatypes"
 	targetNamespace="urn:ebu:tt:datatypes"
     xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
-	<xs:simpleType name="cellResolutionType">
-		<xs:restriction base="xs:token">
-			<xs:pattern value="[0]*[1-9][0-9]*\s[0]*[1-9][0-9]*"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="frameRateMultiplierType">
-		<xs:restriction base="xs:token">
-			<xs:pattern value="[0]*[1-9][0-9]*\s[0]*[1-9][0-9]*"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="cellExtentType">
-		<xs:restriction base="xs:token">
-			<xs:pattern value="([+]?\d*\.?\d+(c))\s([+]?\d*\.?\d+(c))"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="percentageExtentType">
-		<xs:restriction base="xs:token">
-			<xs:pattern value="([+]?\d*\.?\d+(%))\s([+]?\d*\.?\d+(%))"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="pixelExtentType">
-		<xs:restriction base="xs:token">
-			<xs:pattern value="([+]?\d*\.?\d+(px))\s([+]?\d*\.?\d+(px))"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="extentType">
-		<xs:union
-			memberTypes="ebuttdt:cellExtentType ebuttdt:percentageExtentType ebuttdt:pixelExtentType"
-		/>
-	</xs:simpleType>
+
 	<xs:simpleType name="fontFamilyType">
 		<xs:restriction base="xs:string"/>
-	</xs:simpleType>
-	<xs:simpleType name="fontSizeType">
-		<xs:union
-			memberTypes="ebuttdt:cellFontSizeType ebuttdt:percentageFontSizeType ebuttdt:pixelFontSizeType"
-		/>
 	</xs:simpleType>
 	<xs:simpleType name="cellFontSizeType">
 		<xs:restriction base="xs:token">
@@ -68,6 +34,11 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 			/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="fontSizeType">
+		<xs:union
+			memberTypes="ebuttdt:cellFontSizeType ebuttdt:percentageFontSizeType ebuttdt:pixelFontSizeType"
+		/>
+	</xs:simpleType>
 	<xs:simpleType name="fontStyleType">
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="normal"/>
@@ -80,94 +51,27 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 			<xs:enumeration value="bold"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="cellLineHeightType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d*\.?\d+(c)"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="percentageLineHeightType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d*\.?\d+(%)"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="pixelLineHeightType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="\d*\.?\d+(px)"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="lineHeightType">
-		<xs:union memberTypes="ebuttdt:percentageLineHeightType ebuttdt:cellLineHeightType ebuttdt:pixelLineHeightType">
-			<xs:simpleType>
-				<xs:restriction base="xs:token">
-					<xs:enumeration value="normal"/>
-				</xs:restriction>
-			</xs:simpleType>
-		</xs:union>
-	</xs:simpleType>
-	<xs:simpleType name="colorType">
-		<xs:union
-			memberTypes="ebuttdt:rgbHexColorType ebuttdt:rgbaHexColorType ebuttdt:rgbColorType ebuttdt:rgbaColorType ebuttdt:namedColorType"
-		/>
-	</xs:simpleType>
-	<xs:simpleType name="cellOriginType">
-		<xs:restriction base="xs:token">
-			<xs:pattern value="([+-]?\d*\.?\d+(c))\s([+-]?\d*\.?\d+(c))"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="percentageOriginType">
-		<xs:restriction base="xs:token">
-			<xs:pattern value="([+-]?\d*\.?\d+(%))\s([+-]?\d*\.?\d+(%))"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="pixelOriginType">
-		<xs:restriction base="xs:token">
-			<xs:pattern value="([+-]?\d*\.?\d+(px))\s([+-]?\d*\.?\d+(px))"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="originType">
-		<xs:union
-			memberTypes="ebuttdt:cellOriginType ebuttdt:pixelOriginType ebuttdt:percentageOriginType"
-		/>
-	</xs:simpleType>
-	<xs:simpleType name="paddingType">
-		<xs:restriction base="xs:token">
-			<xs:pattern
-				value="([+-]?\d*(\.\d+)?(px|c|%))(\s([+-]?\d*(\.\d+)?(px|c|%)))?(\s([+-]?\d*(\.\d+)?(px|c|%)))?(\s([+-]?\d*(\.\d+)?(px|c|%)))?"
-			/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="timingType">
-		<xs:union
-			memberTypes="ebuttdt:smpteTimingType ebuttdt:mediaTimingType ebuttdt:clockTimingType"/>
-	</xs:simpleType>
-	<xs:simpleType name="durationTimingType">
-		<xs:union
-			memberTypes="ebuttdt:clockTimingType ebuttdt:mediaTimingType"/>
-	</xs:simpleType>
 	<xs:simpleType name="smpteTimingType">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="([0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]:[0-9][0-9]"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="clockTimingType">
-		<xs:union memberTypes="ebuttdt:limitedClockTimingType ebuttdt:timecountTimingType"/>
-	</xs:simpleType>
-	<xs:simpleType name="mediaTimingType">
-		<xs:union memberTypes="ebuttdt:timecountTimingType ebuttdt:fullClockTimingType"/>
 	</xs:simpleType>
 	<xs:simpleType name="timecountTimingType">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="[0-9]+(\.[0-9]+)?(h|ms|s|m)"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="fullClockTimingType">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9][0-9]+:[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="mediaTimingType">
+		<xs:union memberTypes="ebuttdt:timecountTimingType ebuttdt:fullClockTimingType"/>
+	</xs:simpleType>
 	<xs:simpleType name="authoringDelayType">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="[+-]?[0-9]+(\.[0-9]+)?(h|ms|s|m)"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="limitedClockTimingType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[0-9][0-9]:[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="noTimezoneDateType">
@@ -175,75 +79,6 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 			<xs:pattern value="[^:Z]*"/>
 		</xs:restriction>
         </xs:simpleType>
-	<xs:simpleType name="fullClockTimingType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[0-9][0-9]+:[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="cellLengthType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[+-]?\d*\.?\d+(c)"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="percentageLengthType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[+-]?\d*\.?\d+(%)"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="pixelLengthType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[+-]?\d*\.?\d+(px)"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="lengthType">
-		<xs:union
-			memberTypes="ebuttdt:cellLengthType ebuttdt:percentageLengthType ebuttdt:pixelLengthType"
-		/>
-	</xs:simpleType>
-	<xs:simpleType name="rgbHexColorType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="#[a-fA-F\d]{6}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="rgbaHexColorType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="#[a-fA-F\d]{8}"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="rgbColorType">
-		<xs:restriction base="xs:token">
-			<xs:pattern value="rgb\(([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\)"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="rgbaColorType">
-		<xs:restriction base="xs:token">
-			<xs:pattern value="rgba\(([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]),\s?([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\)"/>
-		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="namedColorType">
-		<xs:restriction base="xs:token">
-			<xs:enumeration value="transparent"/>
-			<xs:enumeration value="black"/>
-			<xs:enumeration value="silver"/>
-			<xs:enumeration value="gray"/>
-			<xs:enumeration value="white"/>
-			<xs:enumeration value="maroon"/>
-			<xs:enumeration value="red"/>
-			<xs:enumeration value="purple"/>
-			<xs:enumeration value="fuchsia"/>
-			<xs:enumeration value="magenta"/>
-			<xs:enumeration value="green"/>
-			<xs:enumeration value="lime"/>
-			<xs:enumeration value="olive"/>
-			<xs:enumeration value="yellow"/>
-			<xs:enumeration value="navy"/>
-			<xs:enumeration value="blue"/>
-			<xs:enumeration value="teal"/>
-			<xs:enumeration value="aqua"/>
-			<xs:enumeration value="cyan"/>
-		</xs:restriction>
-	</xs:simpleType>
-
 	<xs:simpleType name="transitionStyleAttributeType">
 		<xs:restriction base="xs:token">
 			<xs:enumeration value="block"/>
@@ -251,12 +86,6 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 			<xs:enumeration value="word"/>
 			<xs:enumeration value="partOfWord"/>
 			<xs:enumeration value="groupOfWords"/>
-		</xs:restriction>
-	</xs:simpleType>
-	
-	<xs:simpleType name="distributionMediaTimingType">
-		<xs:restriction base="xs:string">
-			<xs:pattern value="[0-9][0-9]+:[0-5][0-9]:([0-5][0-9]|[0-6][0])(\.[0-9]+)?"/>
 		</xs:restriction>
 	</xs:simpleType>
 </xs:schema>

--- a/ebu-tt-metadata.xsd
+++ b/ebu-tt-metadata.xsd
@@ -541,9 +541,9 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 			<xs:any namespace="##other" processContents="lax" minOccurs="0"
 				maxOccurs="unbounded"/>
 		</xs:sequence>
-		<xs:attribute name="process" type="xs:string" use="required"/>
-		<xs:attribute name="generatedBy" type="xs:anyURI" use="required"/>
-		<xs:attribute name="sourceId" type="xs:anyURI" use="optional"/>
+		<xs:attribute name="process" type="xs:string"/>
+		<xs:attribute name="generatedBy" type="xs:anyURI"/>
+		<xs:attribute name="sourceId" type="xs:anyURI"/>
 		<xs:attribute name="appliedDateTime" type="xs:dateTime"/>
 	</xs:complexType>
 

--- a/ebu-tt-metadata.xsd
+++ b/ebu-tt-metadata.xsd
@@ -541,9 +541,9 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 			<xs:any namespace="##other" processContents="lax" minOccurs="0"
 				maxOccurs="unbounded"/>
 		</xs:sequence>
-		<xs:attribute name="process" type="xs:string"/>
-		<xs:attribute name="generatedBy" type="xs:anyURI"/>
-		<xs:attribute name="sourceId" type="xs:anyURI"/>
+		<xs:attribute name="process" type="xs:string" use="required"/>
+		<xs:attribute name="generatedBy" type="xs:anyURI" use="required"/>
+		<xs:attribute name="sourceId" type="xs:anyURI" use="optional"/>
 		<xs:attribute name="appliedDateTime" type="xs:dateTime"/>
 	</xs:complexType>
 


### PR DESCRIPTION
Closes #25 by removing:

* cellResolutionType
* frameRateMultiplierType
* cellExtentType
* percentageExtentType
* pixelExtentType
* extentType
* cellLineHeightType
* percentageLineHeightType
* pixelLineHeightType
* lineHeightType
* colorType
* cellOriginType
* percentageOriginType
* pixelOriginType
* originType
* paddingType
* timingType
* durationTimingType
* clockTimingType
* limitedClockTimingType
* cellLengthType
* percentageLengthType
* pixelLengthType
* lengthType
* rgbHexColorType
* rgbaHexColorType
* rgbColorType
* rgbaColorType
* namedColorType
* distributionMediaTimingType

Any repositories taking their definition of these types from this repo will need to define them locally or get definitions from some other source.