### PR TITLE
Remove dependency on Schema v1.1

### DIFF
--- a/ebu-tt-m-datatypes.xsd
+++ b/ebu-tt-m-datatypes.xsd
@@ -6,9 +6,8 @@
 	implementation of the specification in EBU-Tech 3390 version 1.0.
 Please note that the EBU-TT XML Schema is a helping document and NOT normative but informative.-->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ebuttdt="urn:ebu:tt:datatypes"
-	targetNamespace="urn:ebu:tt:datatypes"
-    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ebuttmdt="urn:ebu:tt:metadata-datatypes"
+	targetNamespace="urn:ebu:tt:metadata-datatypes">
 	<xs:simpleType name="cellResolutionType">
 		<xs:restriction base="xs:token">
 			<xs:pattern value="[0]*[1-9][0-9]*\s[0]*[1-9][0-9]*"/>
@@ -36,7 +35,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 	</xs:simpleType>
 	<xs:simpleType name="extentType">
 		<xs:union
-			memberTypes="ebuttdt:cellExtentType ebuttdt:percentageExtentType ebuttdt:pixelExtentType"
+			memberTypes="ebuttmdt:cellExtentType ebuttmdt:percentageExtentType ebuttmdt:pixelExtentType"
 		/>
 	</xs:simpleType>
 	<xs:simpleType name="fontFamilyType">
@@ -44,7 +43,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 	</xs:simpleType>
 	<xs:simpleType name="fontSizeType">
 		<xs:union
-			memberTypes="ebuttdt:cellFontSizeType ebuttdt:percentageFontSizeType ebuttdt:pixelFontSizeType"
+			memberTypes="ebuttmdt:cellFontSizeType ebuttmdt:percentageFontSizeType ebuttmdt:pixelFontSizeType"
 		/>
 	</xs:simpleType>
 	<xs:simpleType name="cellFontSizeType">
@@ -96,7 +95,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="lineHeightType">
-		<xs:union memberTypes="ebuttdt:percentageLineHeightType ebuttdt:cellLineHeightType ebuttdt:pixelLineHeightType">
+		<xs:union memberTypes="ebuttmdt:percentageLineHeightType ebuttmdt:cellLineHeightType ebuttmdt:pixelLineHeightType">
 			<xs:simpleType>
 				<xs:restriction base="xs:token">
 					<xs:enumeration value="normal"/>
@@ -106,7 +105,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 	</xs:simpleType>
 	<xs:simpleType name="colorType">
 		<xs:union
-			memberTypes="ebuttdt:rgbHexColorType ebuttdt:rgbaHexColorType ebuttdt:rgbColorType ebuttdt:rgbaColorType ebuttdt:namedColorType"
+			memberTypes="ebuttmdt:rgbHexColorType ebuttmdt:rgbaHexColorType ebuttmdt:rgbColorType ebuttmdt:rgbaColorType ebuttmdt:namedColorType"
 		/>
 	</xs:simpleType>
 	<xs:simpleType name="cellOriginType">
@@ -126,7 +125,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 	</xs:simpleType>
 	<xs:simpleType name="originType">
 		<xs:union
-			memberTypes="ebuttdt:cellOriginType ebuttdt:pixelOriginType ebuttdt:percentageOriginType"
+			memberTypes="ebuttmdt:cellOriginType ebuttmdt:pixelOriginType ebuttmdt:percentageOriginType"
 		/>
 	</xs:simpleType>
 	<xs:simpleType name="paddingType">
@@ -138,11 +137,11 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 	</xs:simpleType>
 	<xs:simpleType name="timingType">
 		<xs:union
-			memberTypes="ebuttdt:smpteTimingType ebuttdt:mediaTimingType ebuttdt:clockTimingType"/>
+			memberTypes="ebuttmdt:smpteTimingType ebuttmdt:mediaTimingType ebuttmdt:clockTimingType"/>
 	</xs:simpleType>
 	<xs:simpleType name="durationTimingType">
 		<xs:union
-			memberTypes="ebuttdt:clockTimingType ebuttdt:mediaTimingType"/>
+			memberTypes="ebuttmdt:clockTimingType ebuttmdt:mediaTimingType"/>
 	</xs:simpleType>
 	<xs:simpleType name="smpteTimingType">
 		<xs:restriction base="xs:string">
@@ -150,13 +149,13 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="clockTimingType">
-		<xs:union memberTypes="ebuttdt:limitedClockTimingType ebuttdt:timecountTimingType"/>
+		<xs:union memberTypes="ebuttmdt:limitedClockTimingType ebuttmdt:timecountTimingType"/>
 	</xs:simpleType>
 	<xs:simpleType name="mediaTimingType">
-		<xs:union memberTypes="ebuttdt:timecountTimingType ebuttdt:fullClockTimingType"/>
+		<xs:union memberTypes="ebuttmdt:timecountTimingType ebuttmdt:fullClockTimingType"/>
 	</xs:simpleType>
 	<xs:simpleType name="startOfProgrammeTimingType">
-		<xs:union memberTypes="ebuttdt:smpteTimingType ebuttdt:clockTimingType"/>
+		<xs:union memberTypes="ebuttmdt:smpteTimingType ebuttmdt:clockTimingType"/>
 	</xs:simpleType>
 	<xs:simpleType name="timecountTimingType">
 		<xs:restriction base="xs:string">
@@ -200,7 +199,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 	</xs:simpleType>
 	<xs:simpleType name="lengthType">
 		<xs:union
-			memberTypes="ebuttdt:cellLengthType ebuttdt:percentageLengthType ebuttdt:pixelLengthType"
+			memberTypes="ebuttmdt:cellLengthType ebuttmdt:percentageLengthType ebuttmdt:pixelLengthType"
 		/>
 	</xs:simpleType>
 	<xs:simpleType name="rgbHexColorType">

--- a/ebu-tt-m-datatypes.xsd
+++ b/ebu-tt-m-datatypes.xsd
@@ -176,7 +176,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		<xs:restriction base="xs:date">
 			<xs:pattern value="[^:Z]*"/>
 		</xs:restriction>
-        </xs:simpleType>
+	</xs:simpleType>
 	<xs:simpleType name="fullClockTimingType">
 		<xs:restriction base="xs:string">
 			<xs:pattern value="[0-9][0-9]+:[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?"/>

--- a/ebu-tt-metadata.xsd
+++ b/ebu-tt-metadata.xsd
@@ -9,13 +9,13 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
 	xmlns="urn:ebu:tt:metadata" 
 	xmlns:ebuttm="urn:ebu:tt:metadata"
-	xmlns:ebuttdt="urn:ebu:tt:datatypes"
+	xmlns:ebuttmdt="urn:ebu:tt:metadata-datatypes"
 	xmlns:ttm="http://www.w3.org/ns/ttml#metadata"
 	targetNamespace="urn:ebu:tt:metadata" 
 	elementFormDefault="qualified"
-	xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
-	<xs:import namespace="urn:ebu:tt:datatypes"
-		schemaLocation="ebu-tt-datatypes.xsd"/>
+	>
+	<xs:import namespace="urn:ebu:tt:metadata-datatypes"
+		schemaLocation="ebu-tt-m-datatypes.xsd"/>
 	<xs:import namespace="http://www.w3.org/ns/ttml#metadata"
 		schemaLocation="metadata.xsd"/>
 	<xs:complexType name="binaryData_type">
@@ -286,9 +286,9 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="relatedMediaDuration"
-		type="ebuttdt:mediaTimingType"/>
+		type="ebuttmdt:mediaTimingType"/>
 	<xs:element name="documentBeginDate"
-		type="ebuttdt:noTimezoneDateType"/>
+		type="ebuttmdt:noTimezoneDateType"/>
 	<xs:element name="localTimeOffset" type="xs:string"/>
 	<xs:element name="referenceClockIdentifier" type="xs:string"/>
 	<xs:element name="broadcastServiceIdentifier">
@@ -358,7 +358,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 				Reference Code (SLR)</xs:documentation>
 		</xs:annotation>
 	</xs:element>
-	<xs:element name="documentCreationDate" type="ebuttdt:creationDateType">
+	<xs:element name="documentCreationDate" type="ebuttmdt:creationDateType">
 		<xs:annotation>
 			<xs:documentation>The date of creation of the EBU-TT
 				document. </xs:documentation>
@@ -396,7 +396,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 				(MNC). </xs:documentation>
 		</xs:annotation>
 	</xs:element>
-	<xs:element name="documentStartOfProgramme"	type="ebuttdt:startOfProgrammeTimingType">
+	<xs:element name="documentStartOfProgramme"	type="ebuttmdt:startOfProgrammeTimingType">
 		<xs:annotation>
 			<xs:documentation>The time code of the first frame of the
 				recorded video signal which is intended for
@@ -626,11 +626,11 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
 				<xs:attribute name="fontFamilyName"
-					type="ebuttdt:fontFamilyType" use="required"/>
+					type="ebuttmdt:fontFamilyType" use="required"/>
 				<xs:attribute name="src" type="xs:anyURI" use="required"/>
-				<xs:attribute name="fontStyle" type="ebuttdt:fontStyleType"/>
-				<xs:attribute name="fontWeight" type="ebuttdt:fontWeightType"/>
-				<xs:attribute name="fontSize" type="ebuttdt:fontSizeType"/>
+				<xs:attribute name="fontStyle" type="ebuttmdt:fontStyleType"/>
+				<xs:attribute name="fontWeight" type="ebuttmdt:fontWeightType"/>
+				<xs:attribute name="fontSize" type="ebuttmdt:fontSizeType"/>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>
@@ -648,7 +648,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		</xs:simpleContent>
 	</xs:complexType>
 
-	<xs:attribute name="authoringDelay" type="ebuttdt:authoringDelayType">
+	<xs:attribute name="authoringDelay" type="ebuttmdt:authoringDelayType">
 		<xs:annotation>
 			<xs:documentation> The authoring delay associated with the timed
 				content within this document may be indicated using the
@@ -682,13 +682,13 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 	</xs:complexType>
 
 	<xs:complexType name="documentTransitionStyle_type" mixed="false">
-		<xs:attribute name="inUnit" type="ebuttdt:transitionStyleAttributeType" use="required"/>
-		<xs:attribute name="outUnit" type="ebuttdt:transitionStyleAttributeType" use="required"/>
+		<xs:attribute name="inUnit" type="ebuttmdt:transitionStyleAttributeType" use="required"/>
+		<xs:attribute name="outUnit" type="ebuttmdt:transitionStyleAttributeType" use="required"/>
 	</xs:complexType>
 
 	<xs:complexType name="transitionStyle_type">
-		<xs:attribute name="inUnit" type="ebuttdt:transitionStyleAttributeType" use="required"/>
-		<xs:attribute name="outUnit" type="ebuttdt:transitionStyleAttributeType" use="required"/>
+		<xs:attribute name="inUnit" type="ebuttmdt:transitionStyleAttributeType" use="required"/>
+		<xs:attribute name="outUnit" type="ebuttmdt:transitionStyleAttributeType" use="required"/>
 	</xs:complexType>
 	
 	<xs:complexType name="anyMetadata_type">
@@ -697,7 +697,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 				information.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:any namespace="not http://www.w3.org/ns/ttml urn:ebu:tt"
+			<xs:any namespace="##other"
 				minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
 		</xs:sequence>
 	</xs:complexType>
@@ -730,8 +730,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 					<xs:element name="binaryData" type="binaryData_type"
 						minOccurs="0" maxOccurs="unbounded"/>
 					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax"
-						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+						processContents="lax" namespace="##local"
 					/>
 				</xs:sequence>
 			</xs:extension>
@@ -750,8 +749,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 					<xs:element name="facet" type="facet_type" minOccurs="0"
 						maxOccurs="unbounded"/>
 					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax"
-						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+						processContents="lax" namespace="##local"
 					/>
 				</xs:sequence>
 			</xs:extension>
@@ -772,8 +770,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 					<xs:element name="facet" type="facet_type" minOccurs="0"
 						maxOccurs="unbounded"/>
 					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax"
-						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+						processContents="lax" namespace="##local"
 					/>
 				</xs:sequence>
 			</xs:extension>
@@ -792,8 +789,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 					<xs:element name="facet" type="facet_type" minOccurs="0"
 						maxOccurs="unbounded"/>
 					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax"
-						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+						processContents="lax" namespace="##local"
 					/>
 				</xs:sequence>
 			</xs:extension>
@@ -807,8 +803,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 					<xs:element name="facet" type="facet_type" minOccurs="0"
 						maxOccurs="unbounded"/>
 					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax"
-						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+						processContents="lax" namespace="##local"
 					/>
 				</xs:sequence>
 			</xs:extension>
@@ -822,8 +817,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 					<xs:element name="font" type="font_type" minOccurs="0"
 						maxOccurs="unbounded"/>
 					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax"
-						notNamespace="http://www.w3.org/ns/ttml urn:ebu:tt:metadata"
+						processContents="lax" namespace="##local"
 					/>
 				</xs:sequence>
 			</xs:extension>

--- a/ebu-tt-metadata.xsd
+++ b/ebu-tt-metadata.xsd
@@ -533,7 +533,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		</xs:choice>
 	</xs:group>
 	
-	<xs:complexType name="documentMetadata">
+	<xs:complexType name="documentMetadata_type">
 		<xs:annotation>
 			<xs:documentation>EBU-TT specific metadata that applies to the whole
 				EBU-TT document.</xs:documentation>
@@ -543,6 +543,7 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		</xs:choice>
 	</xs:complexType>
 
+	<xs:element name="documentMetadata" type="documentMetadata_type"/>
 
 	<xs:complexType name="appliedProcessing_type">
 		<xs:sequence>
@@ -690,138 +691,15 @@ Please note that the EBU-TT XML Schema is a helping document and NOT normative b
 		<xs:attribute name="inUnit" type="ebuttmdt:transitionStyleAttributeType" use="required"/>
 		<xs:attribute name="outUnit" type="ebuttmdt:transitionStyleAttributeType" use="required"/>
 	</xs:complexType>
-	
-	<xs:complexType name="anyMetadata_type">
+
+	<xs:complexType name="metadata_type">
 		<xs:annotation>
 			<xs:documentation>Container for metadata
 				information.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:any namespace="##other"
-				minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+			<xs:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
 		</xs:sequence>
 	</xs:complexType>
-
-	<xs:complexType name="metadataBase_type">
-		<xs:sequence>
-			<xs:element ref="ttm:title" minOccurs="0" maxOccurs="1"/>
-			<xs:element ref="ttm:desc" minOccurs="0" maxOccurs="1"/>
-		</xs:sequence>
-	</xs:complexType>
-
-	<xs:complexType name="headMetadata_type">
-		<xs:complexContent>
-			<xs:extension base="ebuttm:metadataBase_type">
-				<xs:sequence>
-					<xs:choice>
-						<xs:choice minOccurs="1" maxOccurs="unbounded">
-							<xs:group ref="ebu-tt-metadata.class"/>
-						</xs:choice>
-						<xs:element name="documentMetadata"
-							type="ebuttm:documentMetadata">
-							<xs:unique name="unique-documentFacet">
-								<xs:selector xpath="ebuttm:documentFacet"/>
-								<xs:field xpath="."/>
-							</xs:unique>
-						</xs:element>
-					</xs:choice>
-					<xs:element ref="ttm:agent" minOccurs="0"
-						maxOccurs="unbounded"/>
-					<xs:element name="binaryData" type="binaryData_type"
-						minOccurs="0" maxOccurs="unbounded"/>
-					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax" namespace="##local"
-					/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="bodyMetadata_type">
-		<xs:complexContent>
-			<xs:extension base="ebuttm:metadataBase_type">
-				<xs:sequence>
-					<xs:element name="authoringTechnique"
-						type="authoringTechnique_type" minOccurs="0"
-						maxOccurs="unbounded"/>
-					<xs:element name="transitionStyle" type="transitionStyle_type"
-						minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="facet" type="facet_type" minOccurs="0"
-						maxOccurs="unbounded"/>
-					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax" namespace="##local"
-					/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="divMetadata_type">
-		<xs:complexContent>
-			<xs:extension base="ebuttm:metadataBase_type">
-				<xs:sequence>
-					<xs:element name="authoringTechnique"
-						type="authoringTechnique_type" minOccurs="0"
-						maxOccurs="unbounded"/>
-					<xs:element name="binaryData" type="binaryData_type"
-						minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="transitionStyle" type="transitionStyle_type"
-						minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="facet" type="facet_type" minOccurs="0"
-						maxOccurs="unbounded"/>
-					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax" namespace="##local"
-					/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="pMetadata_type">
-		<xs:complexContent>
-			<xs:extension base="ebuttm:metadataBase_type">
-				<xs:sequence>
-					<xs:element name="authoringTechnique"
-						type="authoringTechnique_type" minOccurs="0"
-						maxOccurs="unbounded"/>
-					<xs:element name="transitionStyle" type="transitionStyle_type"
-						minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="facet" type="facet_type" minOccurs="0"
-						maxOccurs="unbounded"/>
-					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax" namespace="##local"
-					/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="spanMetadata_type">
-		<xs:complexContent>
-			<xs:extension base="ebuttm:metadataBase_type">
-				<xs:sequence>
-					<xs:element name="facet" type="facet_type" minOccurs="0"
-						maxOccurs="unbounded"/>
-					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax" namespace="##local"
-					/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-
-	<xs:complexType name="stylingMetadata_type">
-		<xs:complexContent>
-			<xs:extension base="ebuttm:metadataBase_type">
-				<xs:sequence>
-					<xs:element name="font" type="font_type" minOccurs="0"
-						maxOccurs="unbounded"/>
-					<xs:any minOccurs="0" maxOccurs="unbounded"
-						processContents="lax" namespace="##local"
-					/>
-				</xs:sequence>
-			</xs:extension>
-		</xs:complexContent>
-	</xs:complexType>
-
+	
 </xs:schema>


### PR DESCRIPTION
Also make the metadata datatypes in a different namespace from the normal datatypes, for clash avoidance in downstream (referring) schemas.